### PR TITLE
Fix input width error on Electron upgrade

### DIFF
--- a/web/src/scripts/components/input/NumberInput.jsx
+++ b/web/src/scripts/components/input/NumberInput.jsx
@@ -157,6 +157,10 @@ class NumberInput extends Component {
         width: width,
         flex: `0 0 ${width}px`,
       })
+    } else {
+      style = Object.assign({}, style, {
+        width: 0,
+      })
     }
     if (this.props.disabled) {
       style = Object.assign({}, style, {

--- a/web/src/scripts/components/input/StringInput.jsx
+++ b/web/src/scripts/components/input/StringInput.jsx
@@ -97,6 +97,10 @@ class StringInput extends Component {
       style = Object.assign({}, baseStyle, {
         width: this.props.width,
       })
+    } else {
+      style = Object.assign({}, baseStyle, {
+        width: 0,
+      })
     }
 
     return (


### PR DESCRIPTION
This corrects the widths of input elements growing larger than their flex parent.
