### PR TITLE
Add sans-serif fallback to Helvetica styles

### DIFF
--- a/web/src/scripts/containers/Upgrader.jsx
+++ b/web/src/scripts/containers/Upgrader.jsx
@@ -33,7 +33,7 @@ const containerStyle = {
 const upgradeStyle = {
   color: 'rgb(80,80,80)',
   fontSize: 26,
-  fontFamily: 'Helvetica Neue',
+  fontFamily: '"Helvetica Neue", sans-serif',
   marginLeft: 20,
 }
 const flex = {

--- a/web/src/scripts/factories/scaffold/ReactNativeScaffolds/Picker.js
+++ b/web/src/scripts/factories/scaffold/ReactNativeScaffolds/Picker.js
@@ -29,7 +29,7 @@ const Picker = {
     defaultValue: {
       color: 'black',
       fontWeight: 'normal',
-      fontFamily: 'helvetica',
+      fontFamily: 'Helvetica, sans-serif',
       fontSize: 16,
       textAlign: 'center',
     },

--- a/web/src/scripts/factories/scaffold/ReactNativeScaffolds/ProgressViewIOS.js
+++ b/web/src/scripts/factories/scaffold/ReactNativeScaffolds/ProgressViewIOS.js
@@ -29,7 +29,7 @@ const ProgressViewIOS = {
     defaultValue: {
       color: 'black',
       fontWeight: 'normal',
-      fontFamily: 'helvetica',
+      fontFamily: 'Helvetica, sans-serif',
       fontSize: 16,
       textAlign: 'center',
     },

--- a/web/src/scripts/factories/scaffold/ReactNativeScaffolds/Text.js
+++ b/web/src/scripts/factories/scaffold/ReactNativeScaffolds/Text.js
@@ -29,7 +29,7 @@ const Text = {
     defaultValue: {
       color: 'black',
       fontWeight: 'normal',
-      fontFamily: 'helvetica',
+      fontFamily: 'Helvetica, sans-serif',
       fontSize: 16,
       textAlign: 'center',
     },
@@ -40,7 +40,7 @@ const Text = {
     template+='  style={{\n'
     template+='  \tcolor: \'black\',\n'
     template+='  \tfontWeight: \'normal\',\n'
-    template+='  \tfontFamily: \'helvetica\',\n'
+    template+='  \tfontFamily: \'Helvetica, sans-serif\',\n'
     template+='  \tfontSize: 16,\n'
     template+='  \ttextAlign: \'center\',\n'
     template+='  }}>\n'

--- a/web/src/styles/main.scss
+++ b/web/src/styles/main.scss
@@ -127,7 +127,7 @@ html, body, #app {
 %helvetica-smooth {
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
-    font-family: 'Helvetica Neue', 'Lucida Grande';
+    font-family: 'Helvetica Neue', 'Lucida Grande', sans-serif;
 }
 
 .subpixel-antialiased {

--- a/web/tools/ReactNativeTemplates/Text.jsx
+++ b/web/tools/ReactNativeTemplates/Text.jsx
@@ -3,7 +3,7 @@
     color: 'black',
     fontSize: 16,
     fontWeight: 'normal',
-    fontFamily: 'Helvetica Neue',
+    fontFamily: '"Helvetica Neue", sans-serif',
   }}>
   My Text
 </Text>


### PR DESCRIPTION
Helps with appearance on Linux (#10) and Windows (#14) where Helvetica is not generally available.
