### PR TITLE
Add npm registry setting

### DIFF
--- a/desktop/src/handlers/moduleHandler.js
+++ b/desktop/src/handlers/moduleHandler.js
@@ -177,7 +177,14 @@ class ModuleHandler {
         bridge.send(startProgressBar(name, 0))
 
         try {
-          npm.run(['install', '-S', `${name}@${version}`], {cwd: installPath}, (err) => {
+          const command = [
+            'install', '-S', `${name}@${version}`,
+            ...options.registry && ['--registry', options.registry]
+          ]
+
+          Logger.info(`npm ${command.join(' ')}`)
+
+          npm.run(command, {cwd: installPath}, (err) => {
 
             // Ensure a trailing throttled call doesn't fire
             progressCallback.cancel()

--- a/web/src/scripts/api/ModuleClient.js
+++ b/web/src/scripts/api/ModuleClient.js
@@ -25,17 +25,18 @@ import {
 } from 'shared/constants/ipc/ModuleConstants'
 import FetchUtils from '../utils/FetchUtils'
 
-const _importModule = (name, version, path) => {
+const _importModule = (name, version, path, registry) => {
   return {
     type: IMPORT_MODULE,
     name,
     path,
     version,
+    registry,
   }
 }
 
-export const importModule = (name, version, path) => {
-  return request(_importModule(name, version, path))
+export const importModule = (name, version, path, registry) => {
+  return request(_importModule(name, version, path, registry))
 }
 
 export const fetchTemplateText = (url) => {
@@ -46,7 +47,7 @@ export const fetchTemplateMetadata = (url) => {
   return FetchUtils.fetchResource(url).then((result) => result.json())
 }
 
-export const fetchTemplateAndImportDependencies = (deps, textUrl, metadataUrl, path) => {
+export const fetchTemplateAndImportDependencies = (deps, textUrl, metadataUrl, path, registry) => {
 
   if (deps && ! _.isEmpty(deps) && path) {
 
@@ -55,7 +56,7 @@ export const fetchTemplateAndImportDependencies = (deps, textUrl, metadataUrl, p
     const depVersion = deps[depName]
 
     // TODO: consider waiting for npm install to finish
-    importModule(depName, depVersion, path)
+    importModule(depName, depVersion, path, registry)
   }
 
   const performFetch = () => {

--- a/web/src/scripts/components/input/StringInput.jsx
+++ b/web/src/scripts/components/input/StringInput.jsx
@@ -108,6 +108,7 @@ class StringInput extends Component {
         type="text"
         style={style}
         value={this.props.value}
+        placeholder={this.props.placeholder}
         onChange={this._onInputChange}
         onKeyDown={this._onKeyDown}
         onBlur={this._onBlur}/>
@@ -120,6 +121,7 @@ StringInput.propTypes = {
   onChange: React.PropTypes.func.isRequired,
   onSubmit: React.PropTypes.func,
   value: React.PropTypes.string.isRequired,
+  placeholder: React.PropTypes.string,
 }
 
 StringInput.defaultProps = {

--- a/web/src/scripts/components/pages/PreferencesPage.jsx
+++ b/web/src/scripts/components/pages/PreferencesPage.jsx
@@ -77,7 +77,8 @@ class PreferencesPage extends Component {
             vimMode={this.props.editor[PREFERENCES.EDITOR.VIM_MODE]}
             showInvisibles={this.props.editor[PREFERENCES.EDITOR.SHOW_INVISIBLES]}
             highlightActiveLine={this.props.editor[PREFERENCES.EDITOR.HIGHLIGHT_ACTIVE_LINE]}
-            showIndentGuides={this.props.editor[PREFERENCES.EDITOR.SHOW_INDENT_GUIDES]} />
+            showIndentGuides={this.props.editor[PREFERENCES.EDITOR.SHOW_INDENT_GUIDES]}
+            npmRegistry={this.props.editor[PREFERENCES.EDITOR.NPM_REGISTRY]} />
         )
       default:
         return null

--- a/web/src/scripts/components/preferences/EditorPreferences.jsx
+++ b/web/src/scripts/components/preferences/EditorPreferences.jsx
@@ -25,7 +25,7 @@ import SliderInput from '../input/SliderInput'
 import CheckboxInput from '../input/CheckboxInput'
 import ColorInput from '../input/ColorInput'
 
-import { PREFERENCES } from '../../constants/PreferencesConstants'
+import { PREFERENCES, METADATA, CATEGORIES } from '../../constants/PreferencesConstants'
 
 const style = {
   display: 'flex',
@@ -45,6 +45,7 @@ export default ({
   showInvisibles,
   highlightActiveLine,
   showIndentGuides,
+  npmRegistry
 }) => {
   return (
     <div style={style}>
@@ -75,6 +76,14 @@ export default ({
         <CheckboxInput
           value={highlightActiveLine}
           onChange={onPreferenceChange.bind(null, PREFERENCES.EDITOR.HIGHLIGHT_ACTIVE_LINE)} />
+      </FormRow>
+      <FormRow
+        label={'NPM Registry'}
+        labelWidth={LABEL_WIDTH}>
+        <StringInput
+          value={npmRegistry}
+          placeholder={METADATA[CATEGORIES.EDITOR][PREFERENCES[CATEGORIES.EDITOR].NPM_REGISTRY].defaultValue}
+          onChange={onPreferenceChange.bind(null, PREFERENCES.EDITOR.NPM_REGISTRY)} />
       </FormRow>
     </div>
   )

--- a/web/src/scripts/constants/PreferencesConstants.js
+++ b/web/src/scripts/constants/PreferencesConstants.js
@@ -36,6 +36,7 @@ export const PREFERENCES = {
     'SHOW_INVISIBLES',
     'SHOW_INDENT_GUIDES',
     'HIGHLIGHT_ACTIVE_LINE',
+    'NPM_REGISTRY',
   ]),
 }
 
@@ -66,6 +67,9 @@ export const METADATA = {
     },
     [PREFERENCES[CATEGORIES.EDITOR].SHOW_INDENT_GUIDES]: {
       defaultValue: false,
+    },
+    [PREFERENCES[CATEGORIES.EDITOR].NPM_REGISTRY]: {
+      defaultValue: 'https://registry.npmjs.org',
     },
   }
 }

--- a/web/src/scripts/containers/TabbedEditor.jsx
+++ b/web/src/scripts/containers/TabbedEditor.jsx
@@ -100,7 +100,7 @@ class TabbedEditor extends Component {
         item.template.text,
         item.template.metadata,
         this.props.rootPath,
-        options.npmRegistry,
+        this.props.npmRegistry,
       ).then(({text, metadata}) => {
         const {decoDoc} = this.props
 
@@ -121,7 +121,6 @@ class TabbedEditor extends Component {
 
   render() {
     const tabBarHeight = 32
-    const {npmRegistry} = this.props.options
 
     const editorStyle = {
       top: 0,
@@ -232,7 +231,7 @@ class TabbedEditor extends Component {
               <ProgressBar
                 style={progressBarStyle}
                 name={`npm install ${this.props.progressBar.name}` +
-                      (npmRegistry? ` --registry=${npmRegistry}`: '')}
+                      (this.props.npmRegistry? ` --registry=${this.props.npmRegistry}`: '')}
                 progress={this.props.progressBar.progress} />
             )
           }
@@ -301,12 +300,12 @@ const mapStateToProps = (state, ownProps) => {
     filesByTabId,
     progressBar: state.ui.progressBar,
     rootPath: getRootPath(state),
+    npmRegistry: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.NPM_REGISTRY],
     options: {
       keyMap: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.VIM_MODE] ? 'vim' : 'sublime',
       showInvisibles: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.SHOW_INVISIBLES],
       styleActiveLine: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.HIGHLIGHT_ACTIVE_LINE],
       showIndentGuides: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.SHOW_INDENT_GUIDES],
-      npmRegistry: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.NPM_REGISTRY],
     }
   }
 }

--- a/web/src/scripts/containers/TabbedEditor.jsx
+++ b/web/src/scripts/containers/TabbedEditor.jsx
@@ -93,12 +93,14 @@ class TabbedEditor extends Component {
   }
 
   onImportItem(item) {
+    const {options} = this.props
     this.props.dispatch(importComponent(item)).then((payload) => {
       fetchTemplateAndImportDependencies(
         item.dependencies,
         item.template.text,
         item.template.metadata,
-        this.props.rootPath
+        this.props.rootPath,
+        options.npmRegistry,
       ).then(({text, metadata}) => {
         const {decoDoc} = this.props
 
@@ -119,6 +121,7 @@ class TabbedEditor extends Component {
 
   render() {
     const tabBarHeight = 32
+    const {npmRegistry} = this.props.options
 
     const editorStyle = {
       top: 0,
@@ -228,7 +231,8 @@ class TabbedEditor extends Component {
             this.props.progressBar && (
               <ProgressBar
                 style={progressBarStyle}
-                name={`npm install ${this.props.progressBar.name}`}
+                name={`npm install ${this.props.progressBar.name}` +
+                      (npmRegistry? ` --registry=${npmRegistry}`: '')}
                 progress={this.props.progressBar.progress} />
             )
           }
@@ -302,6 +306,7 @@ const mapStateToProps = (state, ownProps) => {
       showInvisibles: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.SHOW_INVISIBLES],
       styleActiveLine: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.HIGHLIGHT_ACTIVE_LINE],
       showIndentGuides: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.SHOW_INDENT_GUIDES],
+      npmRegistry: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.NPM_REGISTRY],
     }
   }
 }


### PR DESCRIPTION
Implement issue #42.

![image](https://cloud.githubusercontent.com/assets/8534639/15627054/67372228-250a-11e6-8731-11e748589fab.png)
This is comparison of time spent in downloading Gifted Messenger component via NPM official registry and Taobao CDN registry.

![image](https://cloud.githubusercontent.com/assets/8534639/15627251/bd92024a-2510-11e6-9286-804554f313cc.png)
I just temporarily added this setting to ```Editor``` tab, but I think it's better to add it to ```General``` tab or another tabs.

