### PR TITLE
if watchman is already in path, do not use our own binary

### DIFF
--- a/desktop/src/handlers/fileHandler.js
+++ b/desktop/src/handlers/fileHandler.js
@@ -121,7 +121,10 @@ function closeWatchman() {
 
 function shutdownWatchman() {
   try {
-    child_process.spawnSync('/usr/local/Deco/watchman/watchman', ['shutdown-server'])
+    // this should only be the case if we added watchman to the $PATH on initialization
+    if (process.env.PATH.indexOf('/usr/local/Deco/watchman') != -1) {
+      child_process.spawnSync('/usr/local/Deco/watchman/watchman', ['shutdown-server'])
+    }
   } catch (e) {
     //do nothing
     Logger.error(e)

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -32,6 +32,7 @@ global.__DEV__ = __DEV__
 global.openWindows = {}
 
 import os from 'os'
+import child_process from 'child_process'
 
 //DECO APP REQUIRES
 var WindowManager = require('./window/windowManager.js')
@@ -53,13 +54,33 @@ app.on('window-all-closed', function() {
   // }
 })
 
+var conditionallyAddWatchmanToPath = function() {
+  // conditionally switch on our custom watchman instance
+  let foundWatchman = false
+  try {
+    const result = child_process.spawnSync('watchman', ['version'], {
+      env: process.env
+    })
+    
+    if (result && result.stdout && result.stdout.toString().length > 0) {
+      foundWatchman = true
+    }
+  } catch (e) {
+    // something went wrong, so we'll fallback to our own
+  }
+  if (!foundWatchman) {
+    process.env.PATH = process.env.PATH + ":" + '/usr/local/Deco/watchman'
+  }
+}
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // THIS IS WHERE DECO APP FUNCTIONALITY SHOULD LIVE, EXERCISE CAUTION OUTSIDE THIS FUNCTION
 app.on('ready', function() {
   //setup environment variables
-  process.env.PATH = process.env.PATH + ":" + '/usr/local/Deco/watchman'
   app.commandLine.appendSwitch('js-flags', '--harmony')
+  conditionallyAddWatchmanToPath()
+
 
   Logger.info('Deco initializing...')
 


### PR DESCRIPTION
Right now we are adding our own watchman binary into Deco's process.env.PATH — we then use this $PATH for the packager, simulator, and for sane (file watching).

This has caused a lot of headaches #62 #39 #36 

So, what we'll do is detect if watchman is reachable on startup (ie. in the PATH) — if it is, we just defer to that watchman. If it isn't, we'll use our own. 

I don't like the option of turning "off" watchman, because not using it has caused problems for us in the past.