### PR TITLE
enable key repet on vim mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ brew install ruby
 gem install bundler
 ```
 
+Enable key repeat if you're running Vim mode:
+
+```
+defaults write com.decosoftware.deco ApplePressAndHoldEnabled -bool false
+```
+
 #### Linux
 
 Linux is not supported at this time.


### PR DESCRIPTION
it's a nightmare to deal with in Deco ide if you're running Vintage (Vim) mode,
as it means you cannot press and hold h/j/k/l to move through your file. 
You have to repeatedly press the keys to navigate.