### PR TITLE
File tree matching uses full path instead of name to identify root

### DIFF
--- a/web/src/scripts/reducers/fileReducer.js
+++ b/web/src/scripts/reducers/fileReducer.js
@@ -60,7 +60,7 @@ const fileReducer = (state = initialState, action) => {
     case ADD_SUB_PATH:
       const addTree = addNode(
         Object.assign({}, state.tree),
-        state.rootName,
+        state.rootPath,
         action.fileInfo
       )
       return Object.assign({}, state, {
@@ -79,7 +79,7 @@ const fileReducer = (state = initialState, action) => {
       _.each(action.paths, (pathInfo) => {
         batchTree = addNode(
           batchTree,
-          state.rootName,
+          state.rootPath,
           pathInfo.fileInfo
         )
       })
@@ -92,7 +92,7 @@ const fileReducer = (state = initialState, action) => {
     {
       const removeTree = removeNode(
         Object.assign({}, state.tree),
-        state.rootName,
+        state.rootPath,
         action.fileInfo
       )
       const filesById = Object.assign({}, state.filesById)
@@ -109,7 +109,7 @@ const fileReducer = (state = initialState, action) => {
       _.each(action.paths, (pathInfo) => {
         batchRemoveTree = removeNode(
           batchRemoveTree,
-          state.rootName,
+          state.rootPath,
           pathInfo.fileInfo
         )
         delete filesById[pathInfo.fileInfo.id]
@@ -173,7 +173,7 @@ const fileReducer = (state = initialState, action) => {
     case REPLACE_NODE:
       const insertTree = updateSubTree(
         Object.assign({}, state.tree),
-        state.rootName,
+        state.rootPath,
         action.node,
         action.oldNode,
       )

--- a/web/src/scripts/utils/treeDiff.js
+++ b/web/src/scripts/utils/treeDiff.js
@@ -123,7 +123,6 @@ export const addNode = (tree, rootPath, fileInfo) => {
       }
     }
   }
-  console.log('arg', fileInfo);
   return addPath(tree, getRelativeRootArray(rootPath, fileInfo.absolutePath), fileInfo)
 }
 

--- a/web/src/scripts/utils/treeDiff.js
+++ b/web/src/scripts/utils/treeDiff.js
@@ -16,12 +16,14 @@
  */
 
 import _ from 'lodash'
-const path = require('path')
+const path = Electron.remote.require('path')
 
 //PRIVATE
 function getRelativeRootArray(rootPath, fullPathArray) {
   const rootParentPath = path.resolve(rootPath, '..')
-  const fullPath = path.join(...fullPathArray)
+  // fullPath needs to be revisited for Windows. The path array currently
+  // chops off the / in the beginning so we add it back here as a workaround.
+  const fullPath = path.sep + path.join(...fullPathArray)
   return path.relative(rootParentPath, fullPath).split(path.sep)
 }
 
@@ -117,8 +119,10 @@ export const addNode = (tree, rootPath, fileInfo) => {
     fileInfo.leaf = true
   } else {
     if (fileInfo.module == [...rootPath.split(path.sep)].pop()) {
-      // Check full path against project root if the name alone matches
-      if (path.relative(path.join(...fileInfo.absolutePath), rootPath) == '') {
+      // Check full path against project root if the name alone matches.
+      // Add path.sep to beginning as a workaround for path array missing /,
+      // needs to be revisited for Windows.
+      if (path.relative(path.sep + path.join(...fileInfo.absolutePath), rootPath) == '') {
         fileInfo.isProjectRoot = true
       }
     }


### PR DESCRIPTION
To get the "relative root array", it was previously using indexOf to find the position of the directory that matches the project name. The name string isn't unique enough of an identifier, so if the same name was present in any directory above the project, it would unexpectedly match that one.

This modifies the behavior to check against the full root path instead. I also renamed the variable "path" to "workingPath" in a few places to avoid confusion with the path module.

Needs more testing. Fixes #66. 