### PR TITLE
add tools to setup node-inspector

### DIFF
--- a/desktop/install-debug-tools.sh
+++ b/desktop/install-debug-tools.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+./node_modules/.bin/node-pre-gyp --target=1.1.2 --runtime=electron --fallback-to-build --directory node_modules/v8-debug/ --dist-url=https://atom.io/download/atom-shell reinstall
+./node_modules/.bin/node-pre-gyp --target=1.1.2 --runtime=electron --fallback-to-build --directory node_modules/v8-profiler/ --dist-url=https://atom.io/download/atom-shell reinstall

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,8 +12,11 @@
     "gulp": "^3.8.11",
     "gulp-fail": "^1.0.1",
     "gulp-load-plugins": "^0.8.1",
+    "gulp-open": "^2.0.0",
     "gulp-shell": "^0.3.0",
     "gulp-util": "^3.0.4",
+    "node-inspector": "^0.12.8",
+    "node-pre-gyp": "^0.6.29",
     "plist": "^1.2.0",
     "run-sequence": "^1.2.1",
     "webpack": "^1.12.14"
@@ -21,6 +24,7 @@
   "scripts": {
     "start": "./node_modules/.bin/gulp start",
     "pack": "./node_modules/.bin/gulp pack",
+    "debug": "./node_modules/.bin/gulp debug",
     "copy-libs": "./node_modules/.bin/gulp dev-unpack-lib",
     "upgrade-project-template": "./node_modules/.bin/gulp upgrade-project-template"
   },

--- a/desktop/webpack.config.js
+++ b/desktop/webpack.config.js
@@ -15,6 +15,7 @@ fs.readdirSync('node_modules')
 module.exports = {
   entry: './src/main.js',
   target: 'atom',
+  devtool: 'inline-source-map',
   output: {
     path: path.join(__dirname, 'build'),
     filename: 'app.js'


### PR DESCRIPTION
node-inspector stuff keeps changing for Electron and the documentation is all out of date — figure we'd make it easy for folks who want to set breakpoints on the desktop side. It's fickle and a little weird, but AFAIK this is how debugging on Electron works.