### PR TITLE
Deprecated animation prop of Modal component is updated

### DIFF
--- a/web/tools/ReactNativeTemplates/Modal.jsx
+++ b/web/tools/ReactNativeTemplates/Modal.jsx
@@ -1,14 +1,14 @@
-<View> 
-  <Modal 
-    animated={true}
+<View>
+  <Modal
+    animationType={"slide"}
     transparent={false}
     visible={(this.state && this.state.modalVisible) || true }>
-    <View 
+    <View
       style={{
         flex: 1, 
-        backgroundColor: '#f5fcff', 
-        alignItems: 'center', 
-        justifyContent: 'center', 
+        backgroundColor: '#f5fcff',
+        alignItems: 'center',
+        justifyContent: 'center',
         padding: 20,
       }}>
       <Text>Hello Modal</Text>


### PR DESCRIPTION
Instead of "animation" prop "animatedType" should be used to set type of the animation. It takes a string as an argument. (slide, fade, none).

Reference: https://github.com/facebook/react-native/commit/2bb1c263dbdce8f92ed5af41a729470238157799#diff-f10b0f56a9a8e108f33971fb4ae915a0L69