### PR TITLE
Batch react updates to prevent double re-render on dispatch

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -43,6 +43,7 @@
     "react-toggle-button": "^2.1.0",
     "react-virtualized": "7.12.1",
     "redux": "^3.3.1",
+    "redux-batched-subscribe": "^0.1.6",
     "redux-thunk": "^1.0.3",
     "reselect": "^2.5.3",
     "semver": "^5.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,7 @@
     "react-toggle-button": "^2.1.0",
     "react-virtualized": "7.12.1",
     "redux": "^3.3.1",
-    "redux-batched-subscribe": "^0.1.6",
+    "redux-batched-subscribe": "dabbott/redux-batched-subscribe#batchActions-built",
     "redux-thunk": "^1.0.3",
     "reselect": "^2.5.3",
     "semver": "^5.1.0",

--- a/web/src/scripts/store/configureStore.dev.js
+++ b/web/src/scripts/store/configureStore.dev.js
@@ -19,7 +19,7 @@ import { createStore, applyMiddleware, compose } from 'redux'
 import { syncHistory } from 'react-router-redux'
 import { hashHistory } from 'react-router'
 import thunk from 'redux-thunk'
-import { batchedSubscribe } from 'redux-batched-subscribe'
+import { batchedSubscribe, batchMiddleware } from 'redux-batched-subscribe'
 import { unstable_batchedUpdates as batchedUpdates } from 'react-dom'
 
 import rootReducer from '../reducers'
@@ -34,9 +34,8 @@ import applyActionEmitters from './applyActionEmitters'
 //DEV
 import DevTools from '../containers/DevTools'
 
-const reduxRouterMiddleware = syncHistory(hashHistory)
 const enhancer = compose(
-  applyMiddleware(thunk, reduxRouterMiddleware, loggingMiddleware),
+  applyMiddleware(batchMiddleware, thunk, syncHistory(hashHistory), loggingMiddleware),
   DevTools.instrument(),
   batchedSubscribe(batchedUpdates)
 )

--- a/web/src/scripts/store/configureStore.dev.js
+++ b/web/src/scripts/store/configureStore.dev.js
@@ -19,6 +19,9 @@ import { createStore, applyMiddleware, compose } from 'redux'
 import { syncHistory } from 'react-router-redux'
 import { hashHistory } from 'react-router'
 import thunk from 'redux-thunk'
+import { batchedSubscribe } from 'redux-batched-subscribe'
+import { unstable_batchedUpdates as batchedUpdates } from 'react-dom'
+
 import rootReducer from '../reducers'
 import loggingMiddleware from './loggingMiddleware'
 import ipcActionEmitter from '../ipc/ipcActionEmitter'
@@ -34,7 +37,8 @@ import DevTools from '../containers/DevTools'
 const reduxRouterMiddleware = syncHistory(hashHistory)
 const enhancer = compose(
   applyMiddleware(thunk, reduxRouterMiddleware, loggingMiddleware),
-  DevTools.instrument()
+  DevTools.instrument(),
+  batchedSubscribe(batchedUpdates)
 )
 
 function getDebugSessionKey() {

--- a/web/src/scripts/store/configureStore.prod.js
+++ b/web/src/scripts/store/configureStore.prod.js
@@ -19,7 +19,7 @@ import { createStore, applyMiddleware, compose } from 'redux'
 import { syncHistory } from 'react-router-redux'
 import { hashHistory } from 'react-router'
 import thunk from 'redux-thunk'
-import { batchedSubscribe } from 'redux-batched-subscribe'
+import { batchedSubscribe, batchMiddleware } from 'redux-batched-subscribe'
 import { unstable_batchedUpdates as batchedUpdates } from 'react-dom'
 
 import rootReducer from '../reducers'
@@ -32,7 +32,7 @@ import moduleActionEmitter from '../persistence/moduleActionEmitter'
 import applyActionEmitters from './applyActionEmitters'
 
 const enhancer = compose(
-  applyMiddleware(thunk, syncHistory(hashHistory), loggingMiddleware),
+  applyMiddleware(batchMiddleware, thunk, syncHistory(hashHistory), loggingMiddleware),
   batchedSubscribe(batchedUpdates)
 )
 

--- a/web/src/scripts/store/configureStore.prod.js
+++ b/web/src/scripts/store/configureStore.prod.js
@@ -19,6 +19,9 @@ import { createStore, applyMiddleware, compose } from 'redux'
 import { syncHistory } from 'react-router-redux'
 import { hashHistory } from 'react-router'
 import thunk from 'redux-thunk'
+import { batchedSubscribe } from 'redux-batched-subscribe'
+import { unstable_batchedUpdates as batchedUpdates } from 'react-dom'
+
 import rootReducer from '../reducers'
 import loggingMiddleware from './loggingMiddleware'
 import ipcActionEmitter from '../ipc/ipcActionEmitter'
@@ -28,7 +31,10 @@ import layoutActionEmitter from '../persistence/layoutActionEmitter'
 import moduleActionEmitter from '../persistence/moduleActionEmitter'
 import applyActionEmitters from './applyActionEmitters'
 
-const enhancer = applyMiddleware(thunk, syncHistory(hashHistory), loggingMiddleware)
+const enhancer = compose(
+  applyMiddleware(thunk, syncHistory(hashHistory), loggingMiddleware),
+  batchedSubscribe(batchedUpdates)
+)
 
 export default function configureStore() {
   const store = createStore(rootReducer, enhancer)


### PR DESCRIPTION
This enables two forms of batching:
1. Batch react-redux renders - container components will only re-render once per redux update, even if they have container parents.
2. Batch actions when dispatched with batchActions([ ...action ])