### PR TITLE
Tabbed editor cleanup

### DIFF
--- a/web/src/scripts/components/index.js
+++ b/web/src/scripts/components/index.js
@@ -16,16 +16,23 @@
  */
 
 // Buttons
-export SimpleButton from './buttons/SimpleButton'
-export LoginButton from './buttons/LoginButton'
 export InspectorButton from './buttons/InspectorButton'
+export LoginButton from './buttons/LoginButton'
+export SimpleButton from './buttons/SimpleButton'
+export Tab from './buttons/Tab'
+
+// Console
+export Console from './console/Console'
 
 // Display
 export NoContent from './display/NoContent'
 export Callout from './display/Callout'
+export ProgressBar from './display/ProgressBar'
 
 // Editor
 export AutocompleteHint from './editor/AutocompleteHint'
+export EditorDropTarget from './editor/EditorDropTarget'
+export EditorToast from './editor/EditorToast'
 
 // File Tree
 export Node from './filetree/Node'
@@ -61,9 +68,10 @@ export Pane from './layout/Pane'
 export TabContainer from './layout/TabContainer'
 
 // Menu
-export FilterableList from './menu/FilterableList'
 export ComponentMenuItem from './menu/ComponentMenuItem'
 export DraggableComponentMenuItem from './menu/DraggableComponentMenuItem'
+export FilterableList from './menu/FilterableList'
+export SearchMenu from './menu/SearchMenu'
 
 // Modal
 export NamingBanner from './modal/NamingBanner'

--- a/web/src/scripts/containers/TabbedEditor.jsx
+++ b/web/src/scripts/containers/TabbedEditor.jsx
@@ -354,8 +354,6 @@ class TabbedEditor extends Component {
     // Show npm registry only if it's not the default
     const showNpmRegistry = npmRegistry && npmRegistry !== DEFAULT_NPM_REGISTRY
 
-    console.log('>> render tabbed editor', this.props)
-
     return (
       <HotKeys
         handlers={this.keyHandlers}

--- a/web/src/scripts/containers/TabbedEditor.jsx
+++ b/web/src/scripts/containers/TabbedEditor.jsx
@@ -15,17 +15,18 @@
  *
  */
 
+const { shell } = Electron
+
 import _ from 'lodash'
 import React, { Component, PropTypes } from 'react'
 import ReactDOM from 'react-dom'
 import { connect } from 'react-redux'
-
-const { shell, remote } = Electron
-const path = remote.require('path')
-
+import { bindActionCreators } from 'redux'
+import { createSelector } from 'reselect'
+import { StylesEnhancer } from 'react-styles-provider'
 import { HotKeys } from 'react-hotkeys'
+import path from 'path'
 
-import EditorDropTarget from '../components/editor/EditorDropTarget'
 import HistoryMiddleware from '../middleware/editor/HistoryMiddleware'
 import TokenMiddleware from '../middleware/editor/TokenMiddleware'
 import ClipboardMiddleware from '../middleware/editor/ClipboardMiddleware'
@@ -33,22 +34,24 @@ import AutocompleteMiddleware from '../middleware/editor/AutocompleteMiddleware'
 import IndentGuideMiddleware from '../middleware/editor/IndentGuideMiddleware'
 import DragAndDropMiddleware from '../middleware/editor/DragAndDropMiddleware'
 import ASTMiddleware from '../middleware/editor/ASTMiddleware'
-import NoContent from '../components/display/NoContent'
-import ProgressBar from '../components/display/ProgressBar'
-import Console from '../components/console/Console'
-import SearchMenu from '../components/menu/SearchMenu'
-import ComponentMenuItem from '../components/menu/ComponentMenuItem'
-import TabContainer from '../components/layout/TabContainer'
-import Tab from '../components/buttons/Tab'
-import EditorToast from '../components/editor/EditorToast'
-import { StylesEnhancer } from 'react-styles-provider'
 
-import { setConsoleVisibility, setConsoleScrollHeight } from '../actions/uiActions'
-import { stopPackager, runPackager, clearConfigError, setFlowError } from '../actions/applicationActions'
-import { insertComponent, insertTemplate } from '../actions/editorActions'
-import { closeTabWindow } from '../actions/compositeFileActions'
+import {
+  EditorDropTarget,
+  NoContent,
+  ProgressBar,
+  Console,
+  SearchMenu,
+  ComponentMenuItem,
+  TabContainer,
+  Tab,
+  EditorToast,
+} from '../components'
+
+import * as uiActions from '../actions/uiActions'
+import * as applicationActions from '../actions/applicationActions'
+import * as editorActions from '../actions/editorActions'
+import * as compositeFileActions from '../actions/compositeFileActions'
 import { fetchTemplateAndImportDependencies } from '../api/ModuleClient'
-import { openFile } from '../actions/compositeFileActions'
 import { installAndStartFlow } from '../utils/FlowUtils'
 import { PACKAGE_ERROR } from '../utils/PackageUtils'
 import { CATEGORIES, METADATA, PREFERENCES } from 'shared/constants/PreferencesConstants'
@@ -106,42 +109,70 @@ const stylesCreator = ({colors}) => {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
-  const tabIds = _.get(state, `ui.tabs.${CONTENT_PANES.CENTER}.tabIds`, [])
-  const filesByTabId = {}
-  _.each(tabIds, (tabId) => {
-    filesByTabId[tabId] = state.directory.filesById[tabId] || {}
+const editorOptionsSelector = createSelector(
+  (state) => state.preferences,
+  (preferences) => ({
+    theme: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.THEME],
+    fontSize: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.FONT_SIZE],
+    keyMap: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.VIM_MODE] ? 'vim' : 'sublime',
+    showInvisibles: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.SHOW_INVISIBLES],
+    styleActiveLine: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.HIGHLIGHT_ACTIVE_LINE],
+    showIndentGuides: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.SHOW_INDENT_GUIDES],
   })
+)
 
-  const publishingFeature = state.preferences[CATEGORIES.GENERAL][PREFERENCES.GENERAL.PUBLISHING_FEATURE]
+const emptyArray = []
 
-  return {
-    module: module,
-    rootPath: state.directory.rootPath,
-    componentList: publishingFeature ? state.components.list : state.modules.modules,
-    consoleVisible: state.ui.consoleVisible,
-    packagerOutput: state.application.packagerOutput,
-    packagerStatus: state.application.packagerStatus,
-    savedScrollHeight: state.ui.scrollHeight,
-    liveValuesById: state.metadata.liveValues.liveValuesById,
-    focusedTabId: _.get(state, `ui.tabs.${CONTENT_PANES.CENTER}.focusedTabId`),
-    tabIds,
+const filesByTabIdSelector = createSelector(
+  ({directory}) => directory.filesById,
+  ({ui: {tabs}}) => _.get(tabs, `${CONTENT_PANES.CENTER}.tabIds`, emptyArray),
+  (filesById, tabIds) => tabIds.reduce((acc, tabId) => {
+    acc[tabId] = filesById[tabId]
+    return acc
+  }, {})
+)
+
+const mapStateToProps = (state) => createSelector(
+  filesByTabIdSelector,
+  ({directory}) => directory.rootPath,
+  ({ui: {tabs}}) => ({
+    focusedTabId: _.get(tabs, `${CONTENT_PANES.CENTER}.focusedTabId`),
+    tabIds: _.get(tabs, `${CONTENT_PANES.CENTER}.tabIds`, emptyArray),
+  }),
+  ({components, modules, preferences}) => {
+    const publishingFeature = preferences[CATEGORIES.GENERAL][PREFERENCES.GENERAL.PUBLISHING_FEATURE]
+
+    return publishingFeature ? components.list : modules.modules
+  },
+  ({ui}) => ({
+    consoleVisible: ui.consoleVisible,
+    savedScrollHeight: ui.scrollHeight,
+    progressBar: ui.progressBar,
+  }),
+  ({application}) => ({
+    packagerOutput: application.packagerOutput,
+    packagerStatus: application.packagerStatus,
+    configError: application.configError,
+    flowError: application.flowError,
+  }),
+  ({metadata}) => metadata.liveValues.liveValuesById,
+  ({preferences}) => ({
+    npmRegistry: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.NPM_REGISTRY],
+    publishingFeature: preferences[CATEGORIES.GENERAL][PREFERENCES.GENERAL.PUBLISHING_FEATURE],
+  }),
+  editorOptionsSelector,
+  (filesByTabId, rootPath, tabs, componentList, ui, application, liveValuesById, preferences, editorOptions) => ({
     filesByTabId,
-    progressBar: state.ui.progressBar,
-    npmRegistry: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.NPM_REGISTRY],
-    publishingFeature,
-    configError: state.application.configError,
-    flowError: state.application.flowError,
-    options: {
-      theme: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.THEME],
-      fontSize: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.FONT_SIZE],
-      keyMap: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.VIM_MODE] ? 'vim' : 'sublime',
-      showInvisibles: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.SHOW_INVISIBLES],
-      styleActiveLine: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.HIGHLIGHT_ACTIVE_LINE],
-      showIndentGuides: state.preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.SHOW_INDENT_GUIDES],
-    }
-  }
-}
+    rootPath,
+    ...tabs,
+    componentList,
+    ...ui,
+    ...application,
+    liveValuesById,
+    ...preferences,
+    options: editorOptions,
+  })
+)
 
 @StylesEnhancer(stylesCreator)
 class TabbedEditor extends Component {
@@ -212,7 +243,7 @@ class TabbedEditor extends Component {
         return
       }
 
-      this.props.dispatch(insertTemplate(
+      this.props.dispatch(editorActions.insertTemplate(
         decoDoc,
         text,
         metadata,
@@ -222,36 +253,36 @@ class TabbedEditor extends Component {
     })
   }
 
-  onFocusTab = (tabId) => this.props.dispatch(openFile(this.props.filesByTabId[tabId].path))
+  onFocusTab = (tabId) => this.props.dispatch(compositeFileActions.openFile(this.props.filesByTabId[tabId].path))
 
-  onCloseTab = (tabId) => this.props.dispatch(closeTabWindow(tabId))
+  onCloseTab = (tabId) => this.props.dispatch(compositeFileActions.closeTabWindow(tabId))
 
-  onCloseConfigErrorToast = () => this.props.dispatch(clearConfigError())
+  onCloseConfigErrorToast = () => this.props.dispatch(applicationActions.clearConfigError())
 
-  onCloseFlowErrorToast = () => this.props.dispatch(setFlowError(null))
+  onCloseFlowErrorToast = () => this.props.dispatch(applicationActions.setFlowError(null))
 
   onInstallFlow = () => {
     const {rootPath, npmRegistry} = this.props
 
-    this.props.dispatch(setFlowError(null))
+    this.props.dispatch(applicationActions.setFlowError(null))
     installAndStartFlow(rootPath, npmRegistry)
   }
 
   toggleConsole = () => {
     const {consoleVisible} = this.props
 
-    this.props.dispatch(setConsoleVisibility(!consoleVisible))
+    this.props.dispatch(uiActions.setConsoleVisibility(!consoleVisible))
   }
 
   togglePackager = (isRunning) => {
     if (isRunning) {
-      this.props.dispatch(stopPackager())
+      this.props.dispatch(applicationActions.stopPackager())
     } else {
-      this.props.dispatch(runPackager())
+      this.props.dispatch(applicationActions.runPackager())
     }
   }
 
-  saveScrollHeight = (scrollHeight) => this.props.dispatch(setConsoleScrollHeight(scrollHeight))
+  saveScrollHeight = (scrollHeight) => this.props.dispatch(uiActions.setConsoleScrollHeight(scrollHeight))
 
   // Delay allows key events to finish first?
   // TODO: move search menu to top level and take care of this on that refactor
@@ -343,6 +374,8 @@ class TabbedEditor extends Component {
 
     // Show npm registry only if it's not the default
     const showNpmRegistry = npmRegistry && npmRegistry !== DEFAULT_NPM_REGISTRY
+
+    console.log('>> render tabbed editor', this.props)
 
     return (
       <HotKeys

--- a/web/src/scripts/reducers/fileReducer.js
+++ b/web/src/scripts/reducers/fileReducer.js
@@ -23,6 +23,8 @@ import {
   MARK_SAVED,
   MARK_UNSAVED,
   CLEAR_FILE_STATE,
+  UPDATE_FILE_TREE_VERSION,
+  SET_TOP_DIR,
 } from '../actions/fileActions'
 
 const initialState = {
@@ -67,11 +69,16 @@ const fileReducer = (state = initialState, action) => {
       return {
         ...initialState,
       }
-    default:
+    case UPDATE_FILE_TREE_VERSION:
       return {
         ...state,
-        ...payload,
+        version: payload.version,
       }
+    case SET_TOP_DIR:
+      const {rootPath, rootName} = payload
+      return {...state, rootPath, rootName}
+    default:
+      return state
   }
 }
 

--- a/web/src/scripts/reducers/uiReducer.js
+++ b/web/src/scripts/reducers/uiReducer.js
@@ -66,9 +66,11 @@ const initialState = {
 
 const uiReducer = (state = initialState, action) => {
 
-  state = _.cloneDeep(state)
-  state.tabs = tabReducer(state.tabs, action)
-  state.publishing = publishing(state.publishing, action)
+  state = {
+    ...state,
+    tabs: tabReducer(state.tabs, action),
+    publishing: publishing(state.publishing, action),
+  }
 
   switch(action.type) {
     case WINDOW_SIZE_CHANGED:

--- a/web/src/scripts/selectors/index.js
+++ b/web/src/scripts/selectors/index.js
@@ -1,0 +1,27 @@
+import { createSelector } from 'reselect'
+
+import { CATEGORIES, METADATA, PREFERENCES } from 'shared/constants/PreferencesConstants'
+import { CONTENT_PANES } from '../constants/LayoutConstants'
+
+export const editorOptions = createSelector(
+  (state) => state.preferences,
+  (preferences) => ({
+    theme: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.THEME],
+    fontSize: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.FONT_SIZE],
+    keyMap: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.VIM_MODE] ? 'vim' : 'sublime',
+    showInvisibles: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.SHOW_INVISIBLES],
+    styleActiveLine: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.HIGHLIGHT_ACTIVE_LINE],
+    showIndentGuides: preferences[CATEGORIES.EDITOR][PREFERENCES.EDITOR.SHOW_INDENT_GUIDES],
+  })
+)
+
+const emptyArray = []
+
+export const filesByTabId = createSelector(
+  ({directory}) => directory.filesById,
+  ({ui: {tabs}}) => _.get(tabs, `${CONTENT_PANES.CENTER}.tabIds`, emptyArray),
+  (filesById, tabIds) => tabIds.reduce((acc, tabId) => {
+    acc[tabId] = filesById[tabId]
+    return acc
+  }, {})
+)


### PR DESCRIPTION
Prevent tabbed editor from re-rendering while typing.
- remove catch-all {...state, ...payload} from files reducer
- handle SET_TOP_DIR and file tree version updates in files reducer
- remove _.cloneDeep(state) from ui reducer
- clean up and add selectors to TabbedEditor

Created selectors file