### PR TITLE
Yops updates - Entry scene, click scene, import and addfunction improvements

### DIFF
--- a/desktop/src/utils/codemod/expressionMethods.js
+++ b/desktop/src/utils/codemod/expressionMethods.js
@@ -129,7 +129,7 @@ const nodeHasValue = (node, value) => {
 export const addFunctionCall = function(object, property, args) {
   const rangeOfLastMatching = getLastMatchingExpressionRange(this, object, property)
   const body = _.get(this.nodes(), '[0].program.body')
-  let newFunctionIndex = 0
+  let newFunctionIndex = body.length
   if (rangeOfLastMatching) {
     newFunctionIndex = _.map(body, 'range').indexOf(rangeOfLastMatching) + 1
   }

--- a/desktop/src/utils/codemod/expressionMethods.js
+++ b/desktop/src/utils/codemod/expressionMethods.js
@@ -129,7 +129,9 @@ const nodeHasValue = (node, value) => {
 export const addFunctionCall = function(object, property, args) {
   const rangeOfLastMatching = getLastMatchingExpressionRange(this, object, property)
   const body = _.get(this.nodes(), '[0].program.body')
-  let newFunctionIndex = body.length
+  // Let's do this the correct way with insertBefore, etc and
+  // generally smarter logic on all these inserts
+  let newFunctionIndex = body.length - 1
   if (rangeOfLastMatching) {
     newFunctionIndex = _.map(body, 'range').indexOf(rangeOfLastMatching) + 1
   }

--- a/web/package.json
+++ b/web/package.json
@@ -56,7 +56,7 @@
     "uuid": "^2.0.1",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.11.0",
-    "yops": "decosoftware/yops"
+    "yops": "0.0.2"
   },
   "homepage": "decosoftware.com",
   "keywords": [

--- a/web/src/scripts/containers/Storyboard.jsx
+++ b/web/src/scripts/containers/Storyboard.jsx
@@ -76,6 +76,7 @@ class Storyboard extends Component {
           connections={connections}
           scenes={scenes}
           onDeleteScene={storyboardActions.deleteScene}
+          onClickScene={storyboardActions.updateEntryScene}
           syncServiceAddress={syncServiceAddress}
           onLayoutUpdate={onLayoutUpdate}
         />

--- a/web/src/scripts/reducers/storyboardReducer.js
+++ b/web/src/scripts/reducers/storyboardReducer.js
@@ -73,7 +73,11 @@ export default (state = initialState, action) => {
     }
 
     case at.SET_ENTRY_SCENE: {
-      return {...state}
+      return update(state, {
+        entry: {
+          $set: payload,
+        },
+      })
     }
 
     default: {


### PR DESCRIPTION
- If entry scene is deleted, replace entry scene with another existing scene
- When a scene is clicked, make it the entry so simulator updates with that content
- Add imports at the end of existing import lists
- Add new functions after last call of the same function structure

So we end up with 

```
import { Navigational, Adapters, SceneManager } from 'deco-sdk'
Navigational.registerAdapter(Adapters.NavigatorIOSAdapter)

import Boddy from './Boddy'
import NewScene from './NewScene'

SceneManager.registerScene("Boddy", Boddy)
SceneManager.registerScene("NewScene", NewScene)

export default SceneManager.registerEntryScene("Boddy")
```