### PR TITLE
Blurred yops bg

### DIFF
--- a/desktop/gulpfile.babel.js
+++ b/desktop/gulpfile.babel.js
@@ -81,7 +81,12 @@ gulp.task('dist', ['modify-plist'], (callback) => {
 })
 
 gulp.task('rebuild-native-modules', () => {
-  es(`${paths.electron_rebuild} --pre-gyp-fix --node-module-version ${NODE_MODULES_VERSION} --which-module git-utils`)
+  const modules = ['git-utils', 'nodobjc', 'ffi', 'ref', 'ref-struct']
+
+  modules.forEach(module => {
+    console.log('Building native module', module, 'for version', NODE_MODULES_VERSION)
+    es(`${paths.electron_rebuild} --pre-gyp-fix --node-module-version ${NODE_MODULES_VERSION} --which-module ${module}`)
+  })
 })
 
 gulp.task('setup-pack-folder', function(callback) {
@@ -122,7 +127,7 @@ gulp.task('electron-pack', ['setup-pack-folder'], function(callback) {
     arch: 'all',
     platform: 'darwin',
     icon: path.join(__dirname, '/assets/icons/deco.icns'),
-    version: '1.4.2',
+    version: '1.4.3',
     appVersion: BUILD_VERSION,
     overwrite: true,
     out: path.join(__dirname, '../app/deco'),

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "babel-core": "^6.4.0",
     "babel-runtime": "^6.11.6",
-    "electron-prebuilt": "1.4.2",
+    "electron-prebuilt": "1.4.3",
     "file-tree-server": "0.0.8",
     "file-tree-server-git": "0.0.8",
     "file-tree-server-transport-electron": "0.0.1",
@@ -56,6 +56,7 @@
     "mkdirp": "^0.5.1",
     "mv": "^2.1.1",
     "node-dir": "^0.1.11",
+    "nodobjc": "^2.1.0",
     "npm": "github:dabbott/npm#progress-api",
     "once": "^1.3.3",
     "raven": "^0.10.0",

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -61,6 +61,7 @@ app.on('window-all-closed', function() {
 app.on('ready', function() {
   //setup environment variables
   app.commandLine.appendSwitch('js-flags', '--harmony')
+  app.commandLine.appendSwitch('--enable-experimental-web-platform-features'); 
 
   Logger.info('Deco initializing...')
 

--- a/desktop/src/utils/desktopBackground.js
+++ b/desktop/src/utils/desktopBackground.js
@@ -1,5 +1,6 @@
 
 import Logger from '../log/logger'
+const {nativeImage} = require('electron')
 
 let $
 
@@ -13,7 +14,7 @@ try {
   Logger.error('Failed to load nodobjc.', e)
 }
 
-export const getBackground = () => {
+export const getBackgroundImageURL = () => {
   try {
     const url = $.NSWorkspace('sharedWorkspace')(
       'desktopImageURLForScreen',
@@ -23,6 +24,32 @@ export const getBackground = () => {
     return url.toString()
   } catch (e) {
     Logger.error('Failed to get desktop background image.', e)
+
+    return null
+  }
+}
+
+export const getBackgroundImage = () => {
+  let url = getBackgroundImageURL()
+
+  if (!url) return null
+
+  // The url is encoded, but we want to use it as a file path
+  url = decodeURI(url)
+
+  // Strip the file:// protocol
+  url = url.replace(/^file:\/\//, '')
+
+  try {
+    const image = nativeImage.createFromPath(url)
+
+    // Arbitrarily scale to 512 wide. Since this image will be heavily blurred,
+    // the quality of the image is not important.
+    const scaled = image.resize({width: 512, quality: 'good'})
+
+    return scaled.toDataURL()
+  } catch (e) {
+    Logger.error('Failed to create nativeImage from desktop background url.', e)
 
     return null
   }

--- a/desktop/src/utils/desktopBackground.js
+++ b/desktop/src/utils/desktopBackground.js
@@ -34,14 +34,11 @@ export const getBackgroundImage = () => {
 
   if (!url) return null
 
-  // The url is encoded, but we want to use it as a file path
-  url = decodeURI(url)
-
-  // Strip the file:// protocol
-  url = url.replace(/^file:\/\//, '')
+  // Decode the url and strip the file:// protocol
+  const filepath = decodeURI(url).replace(/^file:\/\//, '')
 
   try {
-    const image = nativeImage.createFromPath(url)
+    const image = nativeImage.createFromPath(filepath)
 
     // Arbitrarily scale to 512 wide. Since this image will be heavily blurred,
     // the quality of the image is not important.
@@ -49,7 +46,7 @@ export const getBackgroundImage = () => {
 
     return scaled.toDataURL()
   } catch (e) {
-    Logger.error('Failed to create nativeImage from desktop background url.', e)
+    Logger.error(`Failed to create nativeImage from desktop background ${url}.`, e)
 
     return null
   }

--- a/desktop/src/utils/desktopBackground.js
+++ b/desktop/src/utils/desktopBackground.js
@@ -1,8 +1,17 @@
-import $ from 'nodobjc'
+
 import Logger from '../log/logger'
 
-// Load Cocoa framework
-$.framework('cocoa')
+let $
+
+try {
+  // Load Obj-C bridge
+  $ = require('nodobjc')
+
+  // Load Cocoa framework
+  $.framework('cocoa')
+} catch (e) {
+  Logger.error('Failed to load nodobjc.', e)
+}
 
 export const getBackground = () => {
   try {

--- a/desktop/src/utils/desktopBackground.js
+++ b/desktop/src/utils/desktopBackground.js
@@ -1,0 +1,20 @@
+import $ from 'nodobjc'
+import Logger from '../log/logger'
+
+// Load Cocoa framework
+$.framework('cocoa')
+
+export const getBackground = () => {
+  try {
+    const url = $.NSWorkspace('sharedWorkspace')(
+      'desktopImageURLForScreen',
+      $.NSScreen('mainScreen')
+    )
+
+    return url.toString()
+  } catch (e) {
+    Logger.error('Failed to get desktop background image.', e)
+
+    return null
+  }
+}

--- a/desktop/src/window/windowManager.js
+++ b/desktop/src/window/windowManager.js
@@ -152,7 +152,11 @@ var WindowManager = {
         height: height || global.workArea.height,
         show: show || true,
         titleBarStyle: 'hidden',
-        icon: path.join(PUBLIC_FOLDER, '/images/deco-icon.png')
+        icon: path.join(PUBLIC_FOLDER, '/images/deco-icon.png'),
+        webPreferences: {
+          experimentalFeatures: true,
+          webSecurity: false,
+        },
       });
 
       intializeMainWindow(browserWindow);

--- a/desktop/src/window/windowManager.js
+++ b/desktop/src/window/windowManager.js
@@ -155,7 +155,6 @@ var WindowManager = {
         icon: path.join(PUBLIC_FOLDER, '/images/deco-icon.png'),
         webPreferences: {
           experimentalFeatures: true,
-          webSecurity: false,
         },
       });
 

--- a/web/src/scripts/containers/Storyboard.jsx
+++ b/web/src/scripts/containers/Storyboard.jsx
@@ -24,27 +24,51 @@ import { StylesEnhancer } from 'react-styles-provider'
 import YOPS from 'yops'
 import path from 'path'
 import { ViewportUtils } from 'react-scene-graph'
+const desktopBackground = Electron.remote.require('./utils/desktopBackground.js')
 
 import * as ContentLoader from '../api/ContentLoader'
 import * as URIUtils from '../utils/URIUtils'
 import { storyboardActions } from '../actions'
 import NewSceneButton from '../components/storyboard/NewSceneButton'
 
-const stylesCreator = ({colors}) => ({
-  container: {
-    backgroundColor: 'white',
-    flex: '1 1 auto',
-    display: 'flex',
-    alignItems: 'stretch',
-    position: 'relative',
-  },
-  storyboard: {
-    flex: '1 1 auto',
-    display: 'flex',
-    alignItems: 'stretch',
-    position: 'relative',
-  },
-})
+const stylesCreator = ({colors}) => {
+  const {availWidth, availHeight} = window.screen
+  const backgroundImageURL = desktopBackground.getBackground()
+
+  return {
+    container: {
+      flex: '1 1 auto',
+      display: 'flex',
+      alignItems: 'stretch',
+      position: 'relative',
+    },
+    storyboard: {
+      flex: '1 1 auto',
+      display: 'flex',
+      alignItems: 'stretch',
+      position: 'relative',
+    },
+    backdropContainer: {
+      position: 'absolute',
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      overflow: 'hidden',
+    },
+    backdrop: {
+      position: 'absolute',
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      WebkitFilter: 'blur(20px) saturate(120%) brightness(50%)',
+      backgroundImage: backgroundImageURL && `url(${backgroundImageURL})`,
+      backgroundSize: `${availWidth}px ${availHeight}px`,
+      transform: 'scale(1.1)',
+    },
+  }
+}
 
 const mapDispatchToProps = (dispatch) => ({
   storyboardActions: bindActionCreators(storyboardActions, dispatch),
@@ -110,6 +134,9 @@ class Storyboard extends Component {
 
     return (
       <div style={styles.container}>
+        <div style={styles.backdropContainer}>
+          <div style={styles.backdrop} />
+        </div>
         <NewSceneButton onClick={storyboardActions.addScene}/>
         <YOPS
           style={styles.storyboard}

--- a/web/src/scripts/containers/Storyboard.jsx
+++ b/web/src/scripts/containers/Storyboard.jsx
@@ -33,7 +33,7 @@ import NewSceneButton from '../components/storyboard/NewSceneButton'
 
 const stylesCreator = ({colors}) => {
   const {availWidth, availHeight} = window.screen
-  const backgroundImageURL = desktopBackground.getBackground()
+  const backgroundImageURL = desktopBackground.getBackgroundImage()
 
   return {
     container: {


### PR DESCRIPTION
Grab the user's desktop background via `nodobjc` (Mac only). Blur it behind yops.

I upgraded electron so we can use `nativeImage.resize` and `nativeImage.crop`. Although not currently used, I also enabled experimental web features so we can use the new CSS `backdrop-filter`. 

I'm sure `nodobjc` can break in a lot of ways, so I wrapped all that stuff in try/catch. Deco binary builds/runs fine.