### PR TITLE
Yops actions cleanup

### DIFF
--- a/web/src/scripts/actions/storyboardActions.js
+++ b/web/src/scripts/actions/storyboardActions.js
@@ -106,7 +106,7 @@ const createNewSceneScaffold = (rootPath) => {
   return {name: newSceneName, filePath, text}
 }
 
-export const addScene = (storyboardPath) => async (dispatch, getState) => {
+export const createScene = (storyboardPath) => async (dispatch, getState) => {
   const {directory: {rootPath}} = getState()
 
   // Scaffold new scene and write to file

--- a/web/src/scripts/containers/Storyboard.jsx
+++ b/web/src/scripts/containers/Storyboard.jsx
@@ -121,11 +121,12 @@ class Storyboard extends Component {
   render() {
     const {
       connections,
+      fileId,
       scenes,
       storyboardActions,
       styles,
       storyboard,
-      yopsStyle
+      yopsStyle,
     } = this.props
     const {viewport} = this.state
     const syncServiceAddress = 'http://localhost:4082'
@@ -136,7 +137,7 @@ class Storyboard extends Component {
         <div style={styles.backdropContainer}>
           <div style={styles.backdrop} />
         </div>
-        <NewSceneButton onClick={storyboardActions.addScene}/>
+        <NewSceneButton onClick={storyboardActions.addScene.bind(this, fileId)}/>
         <YOPS
           style={styles.storyboard}
           connections={connections}

--- a/web/src/scripts/containers/Storyboard.jsx
+++ b/web/src/scripts/containers/Storyboard.jsx
@@ -142,8 +142,8 @@ class Storyboard extends Component {
           style={styles.storyboard}
           connections={connections}
           scenes={_.keyBy(scenes, 'id')}
-          onDeleteScene={storyboardActions.deleteScene}
-          onClickScene={storyboardActions.updateEntryScene}
+          onDeleteScene={storyboardActions.deleteScene.bind(this, fileId)}
+          onClickScene={storyboardActions.updateEntryScene.bind(this, fileId)}
           syncServiceAddress={syncServiceAddress}
           onLayoutUpdate={onLayoutUpdate}
           onViewportChange={this.onViewportChange}

--- a/web/src/scripts/containers/Storyboard.jsx
+++ b/web/src/scripts/containers/Storyboard.jsx
@@ -118,6 +118,12 @@ class Storyboard extends Component {
     this.setState({viewport})
   }
 
+  createScene = () => this.props.storyboardActions.createScene(this.props.fileId)
+
+  deleteScene = (sceneId) => this.props.storyboardActions.deleteScene(this.props.fileId, sceneId)
+
+  updateEntryScene = (sceneId) => this.props.storyboardActions.updateEntryScene(this.props.fileId, sceneId)
+
   render() {
     const {
       connections,
@@ -137,13 +143,13 @@ class Storyboard extends Component {
         <div style={styles.backdropContainer}>
           <div style={styles.backdrop} />
         </div>
-        <NewSceneButton onClick={storyboardActions.addScene.bind(this, fileId)}/>
+        <NewSceneButton onClick={this.createScene} />
         <YOPS
           style={styles.storyboard}
           connections={connections}
           scenes={_.keyBy(scenes, 'id')}
-          onDeleteScene={storyboardActions.deleteScene.bind(this, fileId)}
-          onClickScene={storyboardActions.updateEntryScene.bind(this, fileId)}
+          onDeleteScene={this.deleteScene}
+          onClickScene={this.updateEntryScene}
           syncServiceAddress={syncServiceAddress}
           onLayoutUpdate={onLayoutUpdate}
           onViewportChange={this.onViewportChange}

--- a/web/src/scripts/containers/Storyboard.jsx
+++ b/web/src/scripts/containers/Storyboard.jsx
@@ -77,7 +77,6 @@ const mapDispatchToProps = (dispatch) => ({
 const mapStateToProps = (state) => createSelector(
   (state) => state.storyboard,
   (storyboard) => ({
-    storyboard: storyboard,
     connections: storyboard.connections,
     scenes: storyboard.scenes,
   })
@@ -141,7 +140,7 @@ class Storyboard extends Component {
         <YOPS
           style={styles.storyboard}
           connections={connections}
-          scenes={scenes}
+          scenes={_.keyBy(scenes, 'id')}
           onDeleteScene={storyboardActions.deleteScene}
           onClickScene={storyboardActions.updateEntryScene}
           syncServiceAddress={syncServiceAddress}

--- a/web/src/scripts/reducers/storyboardReducer.js
+++ b/web/src/scripts/reducers/storyboardReducer.js
@@ -39,7 +39,7 @@ export default (state = initialState, action) => {
     case at.ADD_SCENE: {
       return update(state, {
         scenes: {
-          $merge: payload,
+          $push: [payload],
         },
       })
     }

--- a/web/src/scripts/reducers/storyboardReducer.js
+++ b/web/src/scripts/reducers/storyboardReducer.js
@@ -45,9 +45,11 @@ export default (state = initialState, action) => {
     }
 
     case at.DELETE_SCENE: {
+      const {scenes} = state
+
       return update(state, {
         scenes: {
-          $set: _.omit(state.scenes, payload),
+          $set: scenes.filter(x => x.id !== payload),
         },
       })
     }

--- a/web/src/scripts/utils/storyboard/codeUtils.js
+++ b/web/src/scripts/utils/storyboard/codeUtils.js
@@ -1,26 +1,32 @@
 import _ from 'lodash'
 import ElementTreeBuilder from '../ElementTreeBuilder'
 const CodeMod = Electron.remote.require('./utils/codemod/index.js')
-const path = Electron.remote.require('path')
 
 /**
- * Takes a relative path from an import and, optionally, a root
- * directory path. Returns an absolute file path.
+ * Takes a relative path from an import and returns an absolute file path.
  * './Buddy' -> 'Buddy.js' or '/Users/gabe/Code/Buddy.js'
  */
-const formatFilePaths = (filepath, options = {}) => {
+const relativize = (filepath) => {
   let formedPath = filepath
-  if (formedPath.indexOf('./') != -1) {
+
+  // Strip './' if present
+  if (formedPath.startsWith('./')) {
     formedPath = formedPath.slice(2)
   }
-  if (formedPath.indexOf('.js') == -1) {
-    if (formedPath[formedPath.length - 1] == '/') {
-      formedPath = formedPath.slice(0, formedPath.length - 1)
+
+  // If no .js ending
+  if (formedPath.indexOf('.js') === -1) {
+
+    // Remove an ending '/' if present
+    if (formedPath.endsWith('/')) {
+      formedPath = formedPath.slice(0, -1)
     }
+
+    // Add the .js extension
     formedPath += '.js'
   }
 
-  return options.directoryPath ? path.join(options.directoryPath, formedPath) : formedPath
+  return formedPath
 }
 
 /**
@@ -28,45 +34,36 @@ const formatFilePaths = (filepath, options = {}) => {
  * to return a list of filepaths to load in with their respective
  * scene code
  */
-export const getFilePathsFromStoryboardCode = (code, options) => {
-  const scenes = {}
-  CodeMod(code).getAllImports()
+export const getFilePathsFromStoryboardCode = (code, rootPath) => {
+  return CodeMod(code).getAllImports()
     .filter((_import) => _import.source != 'deco-sdk')
-    .forEach((sceneImport) => {
-      const filepath = _.get(sceneImport, 'source')
-      const formattedPath = formatFilePaths(filepath, options)
-      scenes[formattedPath] = {
-        sceneName: _.get(sceneImport, 'identifiers[0].value'),
-        source: formattedPath,
-      }
-    })
-  return scenes
+    .map((sceneImport) => ({
+      name: _.get(sceneImport, 'identifiers[0].value'),
+      source: relativize(sceneImport.source),
+    }))
 }
 
 /**
- * Takes thes scene code and looks for the push and the pops
+ * Takes the scene code and looks for the push and the pops
  */
 export const getConnectionsInCode = (code) => {
   const mod = CodeMod(code)
-  const pushes = mod.getAllMatchingFunctionCalls(
-    'NavigatorActions',
-    'push'
-  )
-  const pops = mod.getAllMatchingFunctionCalls(
-    'NavigatorActions',
-    'pop'
-  )
-  const connectionsTo = pushes.map(({args, source}) => ({
+
+  const pushCalls = mod.getAllMatchingFunctionCalls('NavigatorActions', 'push')
+  const popCalls = mod.getAllMatchingFunctionCalls('NavigatorActions', 'pop')
+
+  const pushes = pushCalls.map(({args, source}) => ({
+    type: 'push',
     source,
     to: _.get(args, '[0].value')
   }))
-  const connectionsPop = pops.map(({args, source}) => ({
+
+  const pops = popCalls.map(({args, source}) => ({
+    type: 'pop',
     source,
   }))
-  return {
-    pushes: connectionsTo,
-    pops: connectionsPop
-  }
+
+  return [...pushes, ...pops]
 }
 
 export const buildElementTree = (code) => {
@@ -78,24 +75,13 @@ export const buildElementTree = (code) => {
  */
 export const getSceneInformationForStoryboardCode = (code) => {
   const mod = new CodeMod(code)
-  const entryCall = mod.getAllMatchingFunctionCalls(
-    'SceneManager',
-    'registerEntryScene'
-  )
-  const entryScene = _.get(entryCall, '[0].args[0].value')
-  const scenes = {}
-  mod.getAllMatchingFunctionCalls(
-    'SceneManager',
-    'registerScene'
-  ).forEach((sceneCall) => {
-    const sceneName = _.get(sceneCall, 'args[1].value')
-    scenes[sceneName] = {
-      id: sceneName,
-      name: sceneName,
-    }
-  })
-  return {
-    entry: entryScene,
-    scenes,
-  }
+
+  const entryCall = mod.getAllMatchingFunctionCalls('SceneManager', 'registerEntryScene')
+  const entryName = _.get(entryCall, '[0].args[0].value')
+
+  const scenes = mod
+    .getAllMatchingFunctionCalls('SceneManager', 'registerScene')
+    .map((sceneCall) => _.get(sceneCall, 'args[1].value'))
+
+  return {entry: entryName, scenes}
 }

--- a/web/src/scripts/utils/storyboard/codeUtils.js
+++ b/web/src/scripts/utils/storyboard/codeUtils.js
@@ -3,7 +3,7 @@ import ElementTreeBuilder from '../ElementTreeBuilder'
 const CodeMod = Electron.remote.require('./utils/codemod/index.js')
 
 /**
- * Takes a relative path from an import and returns an absolute file path.
+ * Takes a name or relative path and returns a relative path with a .js extension
  * './Buddy' -> 'Buddy.js' or '/Users/gabe/Code/Buddy.js'
  */
 const relativize = (filepath) => {
@@ -34,7 +34,7 @@ const relativize = (filepath) => {
  * to return a list of filepaths to load in with their respective
  * scene code
  */
-export const getFilePathsFromStoryboardCode = (code, rootPath) => {
+export const getFilePathsFromStoryboardCode = (code) => {
   return CodeMod(code).getAllImports()
     .filter((_import) => _import.source != 'deco-sdk')
     .map((sceneImport) => ({


### PR DESCRIPTION
Lots of cleanup here. There were a LOT of things wrong... and there's plenty more to do, but I think it's good enough for now.

Notice how switching to arrays actually got rid of lots of conversions back and forth between objects and arrays! Only one conversion at the very end, which can probably go away if Yops accepts arrays.