### PR TITLE
sort searched files first by depth

### DIFF
--- a/web/src/scripts/components/menu/FilterableList.jsx
+++ b/web/src/scripts/components/menu/FilterableList.jsx
@@ -138,6 +138,11 @@ export default class FilterableList extends Component {
 
     return _.orderBy(filteredList, [
       (pkg) => {
+        if (pkg.name) {
+          return pkg.name.split('/').length
+        }
+      },
+      (pkg) => {
         const name = pkg.displayName || pkg.name
         if (name) {
           return name.toLowerCase()
@@ -148,7 +153,7 @@ export default class FilterableList extends Component {
           return true
         }
       }
-    ], ['asc', 'asc'])
+    ], ['asc', 'asc', 'asc'])
   }
 
   _onSearchTextChange(searchText) {


### PR DESCRIPTION
When you search something like 'package.json' with cmd+p, your base package.json normally sits hundreds of results below nested package.jsons within node_modules. This patch adds a depth-based parameter to the sort, so the base level package.json (and other shallow results for other searches) show up at the top of the list.

Not positive this is the best way to change it, open to ideas.