### PR TITLE
Show full file path on hover tab name

### DIFF
--- a/web/src/scripts/api/ContentLoader.js
+++ b/web/src/scripts/api/ContentLoader.js
@@ -59,11 +59,17 @@ export const getResourceName = (uri) => {
 
   if (loader && loader.getResourceName) {
     const state = getState()
-
     return loader.getResourceName(uri, state)
   } else {
     return path.basename(URIUtils.withoutProtocolOrParams(uri))
   }
+}
+
+export const getResourceNameAndPath = (uri) => {
+  return {
+    name: getResourceName(uri),
+    path: URIUtils.withoutProtocol(uri),
+  };
 }
 
 export const getURIWithLoader = (uri, id) => {

--- a/web/src/scripts/containers/TabPane.jsx
+++ b/web/src/scripts/containers/TabPane.jsx
@@ -105,12 +105,12 @@ class TabPane extends Component {
     const {tabIds = []} = this.props
 
     return tabIds.map((tabId) => {
-      const name = ContentLoader.getResourceName(tabId)
+      const {name, path} = ContentLoader.getResourceNameAndPath(tabId)
 
       return (
         <Tab
           key={tabId}
-          title={name}
+          title={path}
           tabId={tabId}
         >
           {name}


### PR DESCRIPTION
If you have two files open with the same name, it can get confusing which is which. It can also be useful to know the absolute path of a file you have open. This patch uses the full file path as the title for the tab so it shows on hover, rather than just showing the filename again.