### PR TITLE
Autocomplete - disregard case, ignore word being typed, better matching

### DIFF
--- a/web/src/scripts/components/editor/AutocompleteHint.jsx
+++ b/web/src/scripts/components/editor/AutocompleteHint.jsx
@@ -36,22 +36,31 @@ const styles = {
     flexDirection: 'row',
     alignItems: 'center',
   },
-  lighterText: {
-    color: 'rgba(255,255,255,0.5)',
+  text: {
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
   },
 }
 
+styles.boldText = {
+  ...styles.text,
+  fontWeight: 'bold',
+}
+
+styles.lighterText = {
+  ...styles.text,
+  color: 'rgba(255,255,255,0.5)',
+}
+
 export default class extends Component {
-  getFunctionSnippet(functionDetails) {
+  getFunctionSnippet = (functionDetails) => {
     const {params, return_type} = functionDetails
     const paramsSnippet = params.map(param => param.name).join(', ')
     return `(${paramsSnippet}) => ${return_type}`
   }
 
-  renderSnippet(functionDetails, type) {
+  renderSnippet = (functionDetails, type) => {
     if (functionDetails) {
       return (
         <div style={styles.lighterText}>
@@ -69,16 +78,27 @@ export default class extends Component {
     }
   }
 
+  renderHighlightedWord = (text, wordToComplete) => {
+    let result = []
+    let wtcIndex = 0
+    for (let i=0; i<text.length; i++) {
+      if (wordToComplete[wtcIndex] === text[i].toLowerCase()) {
+        result.push(<div key={i} style={styles.boldText}> {text[i]} </div>)
+        wtcIndex++
+      } else {
+        result.push(<div key={i} style={styles.lighterText}> {text[i]} </div>)
+      }
+    }
+    return result
+  }
+
   render() {
     const {text, wordToComplete, type, functionDetails} = this.props
 
     return (
       <div style={styles.item}>
         <div style={styles.left}>
-          <b>{text.slice(0, wordToComplete.length)}</b>
-          <div style={styles.lighterText}>
-            {text.slice(wordToComplete.length)}
-          </div>
+          {this.renderHighlightedWord(text, wordToComplete.toLowerCase())}
         </div>
         <div style={styles.right}>
           {this.renderSnippet(functionDetails, type)}

--- a/web/src/scripts/components/editor/AutocompleteHint.jsx
+++ b/web/src/scripts/components/editor/AutocompleteHint.jsx
@@ -75,7 +75,7 @@ export default class extends Component {
     return (
       <div style={styles.item}>
         <div style={styles.left}>
-          <b>{wordToComplete}</b>
+          <b>{text.slice(0, wordToComplete.length)}</b>
           <div style={styles.lighterText}>
             {text.slice(wordToComplete.length)}
           </div>

--- a/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
+++ b/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
@@ -75,19 +75,10 @@ export default class AutocompleteMiddleware extends Middleware {
   // strToCheck = iNtsr returns true
   // strToCheck = initsa returns false
   containsLettersInOrder(base, strToCheck) {
-    // base = base.toLowerCase()
-    // strToCheck = strToCheck.toLowerCase()
     let highestMatchedIndex = -1
     for (let i=0; i < strToCheck.length; i++) {
       const workingIndex = highestMatchedIndex + 1
       const index = base.substring(workingIndex).indexOf(strToCheck[i]) + workingIndex
-      console.log("base", base)
-      console.log("base.substring(workingIndex)", base.substring(workingIndex))
-      console.log("strToCheck", strToCheck)
-      console.log("strToCheck[i]", strToCheck[i])
-      console.log("workingIndex", workingIndex)
-      console.log("index", index)
-      console.log("highestMatchedIndex", highestMatchedIndex)
       if (index <= highestMatchedIndex)
         return false
       highestMatchedIndex = index
@@ -109,7 +100,6 @@ export default class AutocompleteMiddleware extends Middleware {
       .filter((item) => {
         return item.name !== wordToComplete &&
         this.containsLettersInOrder(item.name.toLowerCase(), wordToComplete.toLowerCase())
-        // item.name.toLowerCase().startsWith(wordToComplete.toLowerCase())
       })
 
       // Remove duplicates

--- a/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
+++ b/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
@@ -79,8 +79,9 @@ export default class AutocompleteMiddleware extends Middleware {
     for (let i=0; i < strToCheck.length; i++) {
       const workingIndex = highestMatchedIndex + 1
       const index = base.substring(workingIndex).indexOf(strToCheck[i]) + workingIndex
-      if (index <= highestMatchedIndex)
+      if (index <= highestMatchedIndex) {
         return false
+      }
       highestMatchedIndex = index
     }
     return true

--- a/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
+++ b/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
@@ -70,6 +70,31 @@ export default class AutocompleteMiddleware extends Middleware {
     ReactDOM.render(root, node)
   }
 
+  // If base = initialString
+  // strToCheck = ini returns true
+  // strToCheck = iNtsr returns true
+  // strToCheck = initsa returns false
+  containsLettersInOrder(base, strToCheck) {
+    // base = base.toLowerCase()
+    // strToCheck = strToCheck.toLowerCase()
+    let highestMatchedIndex = -1
+    for (let i=0; i < strToCheck.length; i++) {
+      const workingIndex = highestMatchedIndex + 1
+      const index = base.substring(workingIndex).indexOf(strToCheck[i]) + workingIndex
+      console.log("base", base)
+      console.log("base.substring(workingIndex)", base.substring(workingIndex))
+      console.log("strToCheck", strToCheck)
+      console.log("strToCheck[i]", strToCheck[i])
+      console.log("workingIndex", workingIndex)
+      console.log("index", index)
+      console.log("highestMatchedIndex", highestMatchedIndex)
+      if (index <= highestMatchedIndex)
+        return false
+      highestMatchedIndex = index
+    }
+    return true
+  }
+
   prepareHint(pos, wordToComplete, completion) {
 
     // Get basic completions from nearby text
@@ -83,7 +108,8 @@ export default class AutocompleteMiddleware extends Middleware {
       // disregarding case
       .filter((item) => {
         return item.name !== wordToComplete &&
-        item.name.toLowerCase().startsWith(wordToComplete.toLowerCase())
+        this.containsLettersInOrder(item.name.toLowerCase(), wordToComplete.toLowerCase())
+        // item.name.toLowerCase().startsWith(wordToComplete.toLowerCase())
       })
 
       // Remove duplicates

--- a/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
+++ b/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
@@ -79,8 +79,12 @@ export default class AutocompleteMiddleware extends Middleware {
     // Join flow completions and basic completions
     const list = _.chain([...completion.result, ...basic])
 
-      // Filter irrelevant completions
-      .filter(item => item.name.startsWith(wordToComplete))
+      // Filter word being typed and irrelevant completions,
+      // disregarding case
+      .filter((item) => {
+        return item.name !== wordToComplete &&
+        item.name.toLowerCase().startsWith(wordToComplete.toLowerCase())
+      })
 
       // Remove duplicates
       .uniqBy('name')


### PR DESCRIPTION
- Remove the word being typed from the list of hints. Its existence there makes it difficult to tab complete what you want, and I don't see a use case for it. 
- Disregard case from the hint comparison, while maintaining it in the UI. This makes it much easier to be lazy and type all lower case and still get results that include uppercase.
- Catch letters that show up anywhere in the word, given that they're in that order. This now makes it act like a smart autocomplete e.g. what Sublime does.

Before: 
<img width="526" alt="screen shot 2016-11-08 at 3 57 15 pm" src="https://cloud.githubusercontent.com/assets/3479242/20122410/429620a2-a5cc-11e6-9699-04c9b5a2fae9.png">

After:
<img width="515" alt="screen shot 2016-11-08 at 3 56 42 pm" src="https://cloud.githubusercontent.com/assets/3479242/20122409/428f493a-a5cc-11e6-871c-42933566b725.png">

After after:
<img width="529" alt="screen shot 2016-11-09 at 1 21 20 pm" src="https://cloud.githubusercontent.com/assets/3479242/20155169/7cddab0a-a67f-11e6-921b-fddf146f136a.png">

