### PR TITLE
Fix 'Save As' Crashing [Ship after #254]

### DIFF
--- a/desktop/gulpfile.babel.js
+++ b/desktop/gulpfile.babel.js
@@ -267,6 +267,7 @@ gulp.task('create-project-template', function(callback) {
     project            : cwd('libs/Project'),
     compressed_modules : cwd('libs/modules.tar.bz2'),
     node_modules       : cwd('libs/Project/node_modules'),
+    ios_binary         : cwd('libs/Project/ios/build/Build/Products/Debug-iphonesimulator'),
   }
 
   // Remove existing Project and compressed modules
@@ -288,6 +289,11 @@ gulp.task('create-project-template', function(callback) {
 
   // Delete node_modules
   es(`rm -rf ${pp.node_modules}`)
+
+  // Git add project binaries. RN project has a .gitignore that
+  // ignores build/ and trumps shallower .gitignore
+  es(`git add -u ${pp.project} ${pp.compressed_modules}`)
+  es(`git add -fu ${pp.ios_binary}`)
 
   callback()
 })

--- a/desktop/src/process/packagerController.js
+++ b/desktop/src/process/packagerController.js
@@ -129,47 +129,31 @@ class PackagerController {
   }
 
   runPackager(opts) {
-    try {
-      this.promiseKillPackager()
-        .then(() => {
-          this._runPackager(opts)
-        }).catch(() => {
-          this._runPackager(opts)
-        })
-    } catch (e) {
-      Logger.error(e)
-    }
+    this.promiseKillPackager()
+      .then(() => {
+        this._runPackager(opts)
+      }).catch(() => {
+        this._runPackager(opts)
+      })
   }
 
   promiseKillPackager() {
     return new Promise((resolve, reject) => {
-      const tryToKill = () => {
-        if (!!this._packagerProcess) {
-          try {
-            this._packagerProcess.kill('SIGINT')
-          } catch(e) {
-            Logger.error(e)
-          }
-        }
-      }
       let killCounter = 0
       const repeatedlyKill = setInterval(() => {
         if (killCounter > 3) {
           reject()
-        } else if (!this._packagerProcess) {
-          resolve()
-          this.emitPackagerState({ isAlive: false })
-        } else if (this._packagerProcess.killed) {
+        } else if (!this._packagerProcess || this._packagerProcess.killed) {
           resolve()
           this.emitPackagerState({ isAlive: false })
         } else {
           killCounter += 1
-          tryToKill() // try to kill again
+          this.killPackager() // try to kill again
           return
         }
         clearInterval(repeatedlyKill)
       }, 150)
-      tryToKill()
+      this.killPackager()
     })
   }
 

--- a/web/src/scripts/actions/applicationActions.js
+++ b/web/src/scripts/actions/applicationActions.js
@@ -170,8 +170,9 @@ function _resumePackager(rootPath) {
   }
 }
 
-export function stopPackager() {
-  return function(dispatch, getState) {
+export const stopPackager = () => async (dispatch, getState) => {
+  if (getState().application.packagerStatus) {
+    console.log("getting in there")
     request(_stopPackager()).then((err) => {
       dispatch(setPackagerStatus(ProcessStatus.OFF))
     })
@@ -360,23 +361,19 @@ export const save = () => {
   }
 }
 
-export const saveAs = () => {
-  return function(dispatch, getState) {
-    //should save files first
-    const state = getState()
-    saveAllFiles(state, dispatch)
-    const rootPath = state.directory.rootPath
-    const waitToOpenDialog = () => {
-      if (_.keys(getState().directory.unsaved).length == 0) {
-        request(_saveAsDialog(rootPath)).then((resp) => {
-          RecentProjectUtils.addProjectPath(resp.path)
-          let resumeState = true
-          request(_openProject(resp.path, resumeState))
-        })
-        return
-      }
-      setTimeout(waitToOpenDialog, 100)
-    }
-    setTimeout(waitToOpenDialog, 100)
+export const saveAs = () => async (dispatch, getState) => {
+  const state = getState()
+  const {directory: rootPath, application: packagerStatus} = state
+  if (packagerStatus) {
+    await dispatch(stopPackager())
   }
+  await saveAllFiles(state, dispatch)
+  request(_saveAsDialog(state.directory.rootPath)).then((resp) => {
+    RecentProjectUtils.addProjectPath(resp.path)
+    if (packagerStatus) {
+      dispatch(runPackager(resp.path))
+    }
+    let resumeState = true
+    request(_openProject(resp.path, resumeState))
+  })
 }

--- a/web/src/scripts/api/ContentLoader.js
+++ b/web/src/scripts/api/ContentLoader.js
@@ -59,11 +59,17 @@ export const getResourceName = (uri) => {
 
   if (loader && loader.getResourceName) {
     const state = getState()
-
     return loader.getResourceName(uri, state)
   } else {
     return path.basename(URIUtils.withoutProtocolOrParams(uri))
   }
+}
+
+export const getResourceNameAndPath = (uri) => {
+  return {
+    name: getResourceName(uri),
+    path: URIUtils.withoutProtocol(uri),
+  };
 }
 
 export const getURIWithLoader = (uri, id) => {

--- a/web/src/scripts/components/editor/AutocompleteHint.jsx
+++ b/web/src/scripts/components/editor/AutocompleteHint.jsx
@@ -36,22 +36,31 @@ const styles = {
     flexDirection: 'row',
     alignItems: 'center',
   },
-  lighterText: {
-    color: 'rgba(255,255,255,0.5)',
+  text: {
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
   },
 }
 
+styles.boldText = {
+  ...styles.text,
+  fontWeight: 'bold',
+}
+
+styles.lighterText = {
+  ...styles.text,
+  color: 'rgba(255,255,255,0.5)',
+}
+
 export default class extends Component {
-  getFunctionSnippet(functionDetails) {
+  getFunctionSnippet = (functionDetails) => {
     const {params, return_type} = functionDetails
     const paramsSnippet = params.map(param => param.name).join(', ')
     return `(${paramsSnippet}) => ${return_type}`
   }
 
-  renderSnippet(functionDetails, type) {
+  renderSnippet = (functionDetails, type) => {
     if (functionDetails) {
       return (
         <div style={styles.lighterText}>
@@ -69,16 +78,27 @@ export default class extends Component {
     }
   }
 
+  renderHighlightedWord = (text, wordToComplete) => {
+    let result = []
+    let wtcIndex = 0
+    for (let i=0; i<text.length; i++) {
+      if (wordToComplete[wtcIndex] === text[i].toLowerCase()) {
+        result.push(<div key={i} style={styles.boldText}> {text[i]} </div>)
+        wtcIndex++
+      } else {
+        result.push(<div key={i} style={styles.lighterText}> {text[i]} </div>)
+      }
+    }
+    return result
+  }
+
   render() {
     const {text, wordToComplete, type, functionDetails} = this.props
 
     return (
       <div style={styles.item}>
         <div style={styles.left}>
-          <b>{text.slice(0, wordToComplete.length)}</b>
-          <div style={styles.lighterText}>
-            {text.slice(wordToComplete.length)}
-          </div>
+          {this.renderHighlightedWord(text, wordToComplete.toLowerCase())}
         </div>
         <div style={styles.right}>
           {this.renderSnippet(functionDetails, type)}

--- a/web/src/scripts/components/editor/AutocompleteHint.jsx
+++ b/web/src/scripts/components/editor/AutocompleteHint.jsx
@@ -75,7 +75,7 @@ export default class extends Component {
     return (
       <div style={styles.item}>
         <div style={styles.left}>
-          <b>{wordToComplete}</b>
+          <b>{text.slice(0, wordToComplete.length)}</b>
           <div style={styles.lighterText}>
             {text.slice(wordToComplete.length)}
           </div>

--- a/web/src/scripts/containers/TabPane.jsx
+++ b/web/src/scripts/containers/TabPane.jsx
@@ -105,12 +105,12 @@ class TabPane extends Component {
     const {tabIds = []} = this.props
 
     return tabIds.map((tabId) => {
-      const name = ContentLoader.getResourceName(tabId)
+      const {name, path} = ContentLoader.getResourceNameAndPath(tabId)
 
       return (
         <Tab
           key={tabId}
-          title={name}
+          title={path}
           tabId={tabId}
         >
           {name}

--- a/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
+++ b/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
@@ -75,19 +75,10 @@ export default class AutocompleteMiddleware extends Middleware {
   // strToCheck = iNtsr returns true
   // strToCheck = initsa returns false
   containsLettersInOrder(base, strToCheck) {
-    // base = base.toLowerCase()
-    // strToCheck = strToCheck.toLowerCase()
     let highestMatchedIndex = -1
     for (let i=0; i < strToCheck.length; i++) {
       const workingIndex = highestMatchedIndex + 1
       const index = base.substring(workingIndex).indexOf(strToCheck[i]) + workingIndex
-      console.log("base", base)
-      console.log("base.substring(workingIndex)", base.substring(workingIndex))
-      console.log("strToCheck", strToCheck)
-      console.log("strToCheck[i]", strToCheck[i])
-      console.log("workingIndex", workingIndex)
-      console.log("index", index)
-      console.log("highestMatchedIndex", highestMatchedIndex)
       if (index <= highestMatchedIndex)
         return false
       highestMatchedIndex = index
@@ -109,7 +100,6 @@ export default class AutocompleteMiddleware extends Middleware {
       .filter((item) => {
         return item.name !== wordToComplete &&
         this.containsLettersInOrder(item.name.toLowerCase(), wordToComplete.toLowerCase())
-        // item.name.toLowerCase().startsWith(wordToComplete.toLowerCase())
       })
 
       // Remove duplicates

--- a/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
+++ b/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
@@ -79,8 +79,9 @@ export default class AutocompleteMiddleware extends Middleware {
     for (let i=0; i < strToCheck.length; i++) {
       const workingIndex = highestMatchedIndex + 1
       const index = base.substring(workingIndex).indexOf(strToCheck[i]) + workingIndex
-      if (index <= highestMatchedIndex)
+      if (index <= highestMatchedIndex) {
         return false
+      }
       highestMatchedIndex = index
     }
     return true

--- a/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
+++ b/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
@@ -70,6 +70,31 @@ export default class AutocompleteMiddleware extends Middleware {
     ReactDOM.render(root, node)
   }
 
+  // If base = initialString
+  // strToCheck = ini returns true
+  // strToCheck = iNtsr returns true
+  // strToCheck = initsa returns false
+  containsLettersInOrder(base, strToCheck) {
+    // base = base.toLowerCase()
+    // strToCheck = strToCheck.toLowerCase()
+    let highestMatchedIndex = -1
+    for (let i=0; i < strToCheck.length; i++) {
+      const workingIndex = highestMatchedIndex + 1
+      const index = base.substring(workingIndex).indexOf(strToCheck[i]) + workingIndex
+      console.log("base", base)
+      console.log("base.substring(workingIndex)", base.substring(workingIndex))
+      console.log("strToCheck", strToCheck)
+      console.log("strToCheck[i]", strToCheck[i])
+      console.log("workingIndex", workingIndex)
+      console.log("index", index)
+      console.log("highestMatchedIndex", highestMatchedIndex)
+      if (index <= highestMatchedIndex)
+        return false
+      highestMatchedIndex = index
+    }
+    return true
+  }
+
   prepareHint(pos, wordToComplete, completion) {
 
     // Get basic completions from nearby text
@@ -83,7 +108,8 @@ export default class AutocompleteMiddleware extends Middleware {
       // disregarding case
       .filter((item) => {
         return item.name !== wordToComplete &&
-        item.name.toLowerCase().startsWith(wordToComplete.toLowerCase())
+        this.containsLettersInOrder(item.name.toLowerCase(), wordToComplete.toLowerCase())
+        // item.name.toLowerCase().startsWith(wordToComplete.toLowerCase())
       })
 
       // Remove duplicates

--- a/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
+++ b/web/src/scripts/middleware/editor/AutocompleteMiddleware.js
@@ -79,8 +79,12 @@ export default class AutocompleteMiddleware extends Middleware {
     // Join flow completions and basic completions
     const list = _.chain([...completion.result, ...basic])
 
-      // Filter irrelevant completions
-      .filter(item => item.name.startsWith(wordToComplete))
+      // Filter word being typed and irrelevant completions,
+      // disregarding case
+      .filter((item) => {
+        return item.name !== wordToComplete &&
+        item.name.toLowerCase().startsWith(wordToComplete.toLowerCase())
+      })
 
       // Remove duplicates
       .uniqBy('name')


### PR DESCRIPTION
Current functionality for 'save as' is to copy project and then make that new project active. This currently crashes in all cases because the packager goes haywire when all the files are moved (part of the copy step). This patch stops the packager first, if it's running. Then it restarts it in the new location. Also includes some random cleanup.

Only the two commits at the end are relevant. The rest need to wait for #254 to go in to clear up.