### PR TITLE
Fix color of find and replace buttons

### DIFF
--- a/web/src/styles/main.scss
+++ b/web/src/styles/main.scss
@@ -678,6 +678,13 @@ input[type=button] {
 	}
 }
 
+// For whatever reason, codemirror's dialog.css
+// is leaving replace button text as white, with
+// white background, so it looks broken
+.CodeMirror-dialog button {
+  color: rgb(63,63,63);
+}
+
 @keyframes progress-bar-flicker {
   0%   { background-color: rgb(35,36,38); }
 	50%  { background-color: lighten(rgb(35,36,38), 10); }


### PR DESCRIPTION
We're importing a dialog.css for the style of CodeMirror's find and replace. After this, the text of the buttons is white, as is the background. This makes replace look broken:

<img width="263" alt="screen shot 2016-11-11 at 12 03 02 pm" src="https://cloud.githubusercontent.com/assets/3479242/20228599/d4f414b8-a806-11e6-9d87-70d8d3e2b9f4.png">

Without completely restyling our replace (as we probably should), this change at least makes it useable:

<img width="250" alt="screen shot 2016-11-11 at 12 05 05 pm" src="https://cloud.githubusercontent.com/assets/3479242/20228662/1dbdb276-a807-11e6-8afa-cefc0d24c515.png">
