### PR TITLE
npm install fails in /desktop

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -43,7 +43,7 @@
     "babel-core": "^6.4.0",
     "babel-runtime": "^6.11.6",
     "deco-simulacra": "1.0.0",
-    "electron-prebuilt": "1.4.3",
+    "electron-prebuilt": "1.2.1",
     "file-tree-server": "0.0.8",
     "file-tree-server-git": "0.0.8",
     "file-tree-server-transport-electron": "0.0.1",


### PR DESCRIPTION
Apparently there is a change of API from electron 1.3.0+, ref: https://github.com/electron/electron/issues/4881#issuecomment-246549433

Error:
```

 CXX(target) Release/obj.target/profiler/src/profiler.o
  CXX(target) Release/obj.target/profiler/src/cpu_profiler.o
  CXX(target) Release/obj.target/profiler/src/cpu_profile.o
  CXX(target) Release/obj.target/profiler/src/cpu_profile_node.o
  CXX(target) Release/obj.target/profiler/src/heap_profiler.o
../src/heap_profiler.cc:35:18: warning: 'TryCatch' is deprecated [-Wdeprecated-declarations]
        TryCatch try_catch;
                 ^
/Users/cesare/.electron-gyp/.node-gyp/iojs-1.4.3/deps/v8/include/v8.h:6932:40: note: 'TryCatch' has been explicitly marked deprecated here
  V8_DEPRECATED("Use isolate version", TryCatch());
                                       ^
1 warning generated.
  CXX(target) Release/obj.target/profiler/src/heap_snapshot.o
../src/heap_snapshot.cc:46:46: error: no member named 'GetHiddenValue' in 'v8::Object'
      info.GetReturnValue().Set(info.This()->GetHiddenValue(__root));
                                ~~~~~~~~~~~  ^
../src/heap_snapshot.cc:50:20: error: no member named 'SetHiddenValue' in 'v8::Object'
      info.This()->SetHiddenValue(__root, _root);
      ~~~~~~~~~~~  ^
2 errors generated.
make: *** [Release/obj.target/profiler/src/heap_snapshot.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:194:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
gyp ERR! System Darwin 16.4.0
gyp ERR! command "/usr/local/Cellar/node/7.7.1/bin/node" "/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/.bin/node-gyp" "rebuild" "--target=1.4.3" "--arch=x64" "--dist-url=https://atom.io/download/electron" "--build-from-source" "--module_name=profiler" "--module_path=/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/v8-profiler/build/profiler/v5.6.5/electron-v1.4-darwin-x64" "--remote_path=./profiler/v5.6.5/" "--package_name=electron-v1.4-darwin-x64.tar.gz" "--host=https://node-inspector.s3.amazonaws.com/"
gyp ERR! cwd /Users/cesare/Projects/electron/deco-ide/desktop/node_modules/v8-profiler
gyp ERR! node -v v7.7.1
gyp ERR! node-gyp -v v3.5.0
gyp ERR! not ok 

Failed with exit code: 1
    at SafeSubscriber.obs.subscribe.e [as _error] (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/spawn-rx/lib/index.js:311:43)
    at SafeSubscriber.__tryOrUnsub (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:234:16)
    at SafeSubscriber.error (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:195:26)
    at Subscriber._error (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:128:26)
    at Subscriber.error (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:102:18)
    at MapSubscriber.Subscriber._error (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:128:26)
    at MapSubscriber.Subscriber.error (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:102:18)
    at SafeSubscriber.pipesClosed.subscribe [as _next] (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/spawn-rx/lib/index.js:284:42)
    at SafeSubscriber.__tryOrUnsub (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:234:16)
    at SafeSubscriber.next (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:183:22)
    at Subscriber._next (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:125:26)
    at Subscriber.next (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:89:18)
    at ReduceSubscriber._complete (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/operator/reduce.js:119:30)
    at ReduceSubscriber.Subscriber.complete (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/Subscriber.js:114:18)
    at MergeAllSubscriber.notifyComplete (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/operator/mergeAll.js:105:30)
    at InnerSubscriber._complete (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/rxjs/InnerSubscriber.js:30:21)
[10:51:32] 'rebuild-native-modules' errored after 3.47 s
[10:51:32] Error: Command failed: /Users/cesare/Projects/electron/deco-ide/desktop/node_modules/.bin/electron-rebuild --pre-gyp-fix --node-module-version 50 --which-module git-utils
    at checkExecSyncError (child_process.js:489:13)
    at execSync (child_process.js:529:13)
    at es (/Users/cesare/Projects/electron/deco-ide/desktop/gulpfile.babel.js:17:35)
    at /Users/cesare/Projects/electron/deco-ide/desktop/gulpfile.babel.js:89:5
    at Array.forEach (native)
    at Gulp.<anonymous> (/Users/cesare/Projects/electron/deco-ide/desktop/gulpfile.babel.js:87:11)
    at module.exports (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/orchestrator/index.js:214:10)
    at Gulp.Orchestrator.start (/Users/cesare/Projects/electron/deco-ide/desktop/node_modules/orchestrator/index.js:134:8)
    at /Users/cesare/Projects/electron/deco-ide/desktop/node_modules/gulp/bin/gulp.js:129:20
    at _combinedTickCallback (internal/process/next_tick.js:73:7)
    at process._tickDomainCallback (internal/process/next_tick.js:128:9)

npm WARN babel-loader@6.3.2 requires a peer of webpack@1 || 2 || ^2.1.0-beta || ^2.2.0-rc but none was installed.
npm WARN DecoIDE-Desktop@0.8.0-beta1 No repository field.
npm WARN DecoIDE-Desktop@0.8.0-beta1 No license field.
npm ERR! Darwin 16.4.0
npm ERR! argv "/usr/local/Cellar/node/7.7.1/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v7.7.1
npm ERR! npm  v4.1.2
npm ERR! code ELIFECYCLE
npm ERR! DecoIDE-Desktop@0.8.0-beta1 postinstall: `gulp rebuild-native-modules`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the DecoIDE-Desktop@0.8.0-beta1 postinstall script 'gulp rebuild-native-modules'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the DecoIDE-Desktop package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     gulp rebuild-native-modules
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs DecoIDE-Desktop
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls DecoIDE-Desktop
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/cesare/Projects/electron/deco-ide/desktop/npm-debug.log
```